### PR TITLE
Remove numbered section headings

### DIFF
--- a/src/components/AboutMe.svelte
+++ b/src/components/AboutMe.svelte
@@ -3,7 +3,7 @@
 </script>
 
 <div class="flex flex-col py-8">
-	<SectionHeading index="01" title="About Me" />
+	<SectionHeading title="About Me" />
 	<p class="mt-5 text-2xl font-semibold text-slate-900 dark:text-white">Hi! I'm Scott.</p>
 	<p class="mt-2 max-w-prose text-lg leading-relaxed">
 		I currently work on access management at Indeed, where I help people get jobs by ensuring large

--- a/src/components/FeaturedApps.svelte
+++ b/src/components/FeaturedApps.svelte
@@ -5,7 +5,7 @@
 </script>
 
 <div class="py-8">
-	<SectionHeading index="04" title="Things I've Built" />
+	<SectionHeading title="Things I've Built" />
 	<div class="mt-5 grid grid-cols-1 gap-4 sm:grid-cols-3">
 		{#each featuredApps as app (app.url)}
 			<AppCard {app} titleTag="h3" />

--- a/src/components/HighLevelDetails.svelte
+++ b/src/components/HighLevelDetails.svelte
@@ -26,7 +26,7 @@
 </script>
 
 <div class="flex flex-col py-8">
-	<SectionHeading index="02" title="At a Glance" />
+	<SectionHeading title="At a Glance" />
 	<div class="mt-5 grid grid-cols-1 gap-3 sm:grid-cols-2">
 		<div class="fact">
 			<span class="fact-icon icon-[pixelarticons--briefcase]" aria-hidden="true"></span>

--- a/src/components/JobDetailsSection.svelte
+++ b/src/components/JobDetailsSection.svelte
@@ -3,7 +3,7 @@
 </script>
 
 <div class="py-8">
-	<SectionHeading index="03" title="Experience" />
+	<SectionHeading title="Experience" />
 	<div class="mt-6 grid grid-cols-1 gap-x-8 sm:grid-cols-[auto_1fr] sm:gap-y-8">
 		<p class="date">2022-Present</p>
 		<div class="job-details">

--- a/src/components/RecentBlogPosts.svelte
+++ b/src/components/RecentBlogPosts.svelte
@@ -7,7 +7,7 @@
 </script>
 
 <div class="py-8">
-	<SectionHeading index="05" title="Recent Blog Posts" />
+	<SectionHeading title="Recent Blog Posts" />
 	<div class="mt-5 flex flex-col gap-4">
 		{#each recentPosts as post (post.slug)}
 			<a

--- a/src/components/SectionHeading.svelte
+++ b/src/components/SectionHeading.svelte
@@ -1,15 +1,11 @@
 <script lang="ts">
 	interface Props {
-		index?: string;
 		title: string;
 	}
-	const { index, title }: Props = $props();
+	const { title }: Props = $props();
 </script>
 
 <div class="flex items-center gap-3">
-	{#if index}
-		<span class="font-mono text-sm font-medium text-indigo-600 dark:text-indigo-400">{index}</span>
-	{/if}
 	<h2 class="font-display text-3xl text-slate-900 dark:text-white">{title}</h2>
 	<div class="ml-1 h-px flex-1 bg-slate-200 dark:bg-slate-800" aria-hidden="true"></div>
 	<span class="h-2 w-2 shrink-0 bg-indigo-500" aria-hidden="true"></span>


### PR DESCRIPTION
## Summary

Removes the numeric labels from homepage section headings while keeping the shared heading component, divider line, and pixel accent.

## Validation

- `npm run check` (passes; existing Svelte/Tailwind CSS warnings remain)
- `npm run lint`
- `npm run build` (passes; existing Svelte CSS/blog image alt warnings remain)
